### PR TITLE
Fixed returned timezone issue

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -16,6 +16,10 @@ var LoginAuthRouter = require("./routes/loginAuth"); //handles login requests
 
 var app = express();
 
+// set the server timezone
+// using UTC so times are neutral and can be adjusted to user's timezone in the client
+process.env.TZ = "UTC";
+
 // MAY NOT BE NEEDED
 // view engine setup
 app.set("views", path.join(__dirname, "views"));


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] Covered the code with tests that prove my fix is effective or that my feature works (note that PRs
without tests will be REJECTED)
- [ ] New and existing unit tests pass locally with my changes

## How Has This Been Tested?

I ran a request (get all messages for a conversation) and compared the returned timestamps to the ones in the DB which were already in UTC timezone.

---

### What is the purpose of your *pull request*?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of your *pull request* and other information

I set the server timezone to UTC so returned timestamps use the UTC timezone. 

Fixes #44 . The problem was in the express setup not Sequelize .