### PR TITLE
Removed unique constraint from Users.displayName

### DIFF
--- a/server/migrations/20210915210411-modify_users_remove_unique_display_name_constraint.js
+++ b/server/migrations/20210915210411-modify_users_remove_unique_display_name_constraint.js
@@ -1,0 +1,18 @@
+"use strict";
+
+module.exports = {
+    up: async (queryInterface) => {
+        await queryInterface.removeConstraint(
+            "Users",
+            "Users_display_name_key"
+        );
+    },
+
+    down: async (queryInterface) => {
+        await queryInterface.addConstraint("Users", {
+            fields: ["display_name"],
+            type: "unique",
+            name: "Users_display_name_key",
+        });
+    }
+};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -2,7 +2,7 @@ module.exports = (sequelize, Sequelize) => {
     const User = sequelize.define("User", {
         //attributes
         id: { primaryKey: true, type: Sequelize.INTEGER, autoIncrement: true, allowNull: false },
-        displayName: { type: Sequelize.STRING(50), allowNull: false, unique: true, field: "display_name" },
+        displayName: { type: Sequelize.STRING(50), allowNull: false, field: "display_name" },
         firstName: { type: Sequelize.STRING(50), allowNull: true , field: "first_name"},
         lastName: { type: Sequelize.STRING(50), allowNull: true, field: "last_name" },
         imageUrl: { type: Sequelize.STRING(2048), allowNull: true, field: "image_url" },


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Covered the code with tests that prove my fix is effective or that my feature works (note that PRs
without tests will be REJECTED)
- [ ] New and existing unit tests pass locally with my changes

## How Has This Been Tested?

I ran the migration and checked to make sure the constraint was removed from my database.

---

### What is the purpose of your *pull request*?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of your *pull request* and other information

Fix #47 by adding a migration to remove the unique constraint on display_name from the Users table in the database and removed "unique: true" from the definition of displayName attribute in the user model.