### PR TITLE
[Feature] Track the online status of users' contacts in the contact list

### DIFF
--- a/client/src/components/messenger/controllers/Contacts.js
+++ b/client/src/components/messenger/controllers/Contacts.js
@@ -24,9 +24,9 @@ export const ContactsController = {
         if (!lastActive)
             return "offline";
         // for now status is either online or offline
-        // if user not active within the last 5mins - offline
+        // if user not active within the last 15 seconds - offline
         let diff = Date.now() - (new Date(lastActive)).getTime();
-        return diff > (5 * 60 * 1000) ? "offline": "online";
+        return diff > (15 * 1000) ? "offline": "online";
     },
     addContact: async (token, email) => {
         const res = await fetch("/api/contacts", {

--- a/server/socketio/connection.js
+++ b/server/socketio/connection.js
@@ -17,6 +17,7 @@ global.io.use((socket, next) => {
             next(new Error("No user information stored in JWT"));
         } else {
             socket.join(user.id);
+            socket.user = user;
             next();
         }
     } catch (e) {
@@ -32,8 +33,7 @@ global.io.on("connection", (socket) => {
         }
     });
 
-    const authToken = socket.handshake.auth.token;
-    const user = jwt.verify(authToken, process.env.TOKEN_SECRET);
+    const { user } = socket;
     // update last active for user every 10 seconds
     const updater = setInterval(() => {
         User.update({
@@ -48,6 +48,6 @@ global.io.on("connection", (socket) => {
         });
     }, 10000);
 
-    // user disconnected, stop their last active
+    // user disconnected, stop updating their last active
     socket.on("disconnect", () => clearInterval(updater));
 });


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

### What is the purpose of your *pull request*?
- [x] Improvement
- [x] New feature (non-breaking change which adds functionality)

### Description of your *pull request* and other information

Upon connection of a client to the server, the server periodically (every 10 secs) updates that user's lastActive status. This value is then used by the user's contacts to determine if they are online or offline (by determining if the last active timestamp is within the last 15 seconds). When a client disconnects from the server, the server stops updating their lastActive status which causes them to appear offline after approximately 15 seconds.