### PR TITLE
Only using colorize for console logs

### DIFF
--- a/server/logger/developmentLogger.js
+++ b/server/logger/developmentLogger.js
@@ -7,12 +7,17 @@ const DevelopmentLogger = () => {
     return createLogger({
         level: "debug",
         format: combine(
-            colorize(),
             timestamp({ format: "HH:mm:ss" }),
             devFormat
         ),
         transports: [
-            new transports.Console(),
+            new transports.Console({
+                format: combine(
+                    colorize(),
+                    timestamp({ format: "HH:mm:ss" }),
+                    devFormat
+                )
+            }),
             new transports.File({ filename: "error.log", level: "error" }),
             new transports.File({ filename: "combined.log" }),
         ],


### PR DESCRIPTION
### I have:
- [X] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] Covered the code with tests that prove my fix is effective or that my feature works (note that PRs
without tests will be REJECTED)
- [ ] New and existing unit tests pass locally with my changes

## How Has This Been Tested?

I ran the server and navigated around then checked the output file and console log

---

### What is the purpose of your *pull request*?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of your *pull request* and other information

I changed the developmentLogger so it would only use colorize for the console log. Without this, it would produce strange outputs in the log file for the level value.

For info level:

    - Before: [22:15:15 ([32minfo[39m)] where ([32minfo[39m) represents the level
    - After: [20:20:30 (info)] where  (info)  represents the level