### PR TITLE
fix: restrict cookie access 🕵️‍♂️🙃

### DIFF
--- a/client/src/styles/login.css
+++ b/client/src/styles/login.css
@@ -91,12 +91,6 @@ div.dots {
     display: flex;
 }
 
-div.slides {
-    display: none;
-    width: 100%;
-    height: 500px;
-}
-
 div.loader {
     margin: auto;
 }

--- a/server/routes/loginAuth.js
+++ b/server/routes/loginAuth.js
@@ -7,20 +7,24 @@ const logger = require("../logger");
 require("./loginStrategies/googleStrategy");
 require("./loginStrategies/facebookStrategy");
 
+const createCookie = (user, res) => {
+    // Creates a cookie with the user's login information
+    res.cookie("loginCookie", user, {
+        secure: false,
+        httpOnly: true,
+        expires: dayjs().add(1, "month").toDate(),
+        sameSite: "Lax"
+    });
+    return res;
+};
+
 router.get("/google", passport.authenticate("google", { scope: ["email", "profile"] }));
 
 // after successful login with google strategy, user db record will be sent here in the req.user property.
 router.get("/google/callback", passport.authenticate("google", { session: false }), (req, res) => {
-    // Creates a cookie with the user's login information
-    res.cookie("loginCookie", JSON.stringify(req.user), {
-        secure: false,
-        httpOnly: true,
-        expires: dayjs().add(1, "month").toDate(),
-    });
-
     // Redirects to the login page and stores the login cookie in the users browser.
     logger.info("Redirected to login: " + req.user);
-    res.status(200).redirect(global.gConfig.homeUrl);
+    createCookie(JSON.stringify(req.user), res).status(200).redirect(global.gConfig.homeUrl);
 });
 
 //Facebook login route
@@ -28,15 +32,9 @@ router.get("/facebook", passport.authenticate("facebook", { scope: ["email", "pu
 
 // after successful login with Facebook strategy, user db record will be sent here in the req.user property.
 router.get("/facebook/callback", passport.authenticate("facebook", { session: false }), (req, res) => {
-    // Creates a cookie with the user's login information
-    res.cookie("loginCookie", JSON.stringify(req.user), {
-        secure: false,
-        httpOnly: true,
-        expires: dayjs().add(1, "month").toDate(),
-    });
-
     // Redirects to the login page and stores the login cookie in the users browser.
-    res.status(200).redirect(global.gConfig.homeUrl);
+    logger.info("Redirected to login: " + req.user);
+    createCookie(JSON.stringify(req.user), res).status(200).redirect(global.gConfig.homeUrl);
 });
 
 // Creates a jwt access token if the cookie with the users login information exists.


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

---

### What is the purpose of your *pull request*?
- [x] Improvement

### Description of your *pull request* and other information

Despite expected behaviour, the login cookie's same site attribute is not set to Lax by default. The PR addresses this by explicitly setting the attribute to prevent other applications from having access to the cookie. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite 

Also an unnecessary css rule was removed. 