### PR TITLE
Fix seeder

### DIFF
--- a/server/seeders/20211122205724-dev_seeder.js
+++ b/server/seeders/20211122205724-dev_seeder.js
@@ -12,15 +12,16 @@ const Participant = db.Participant;
 const Message = db.Message;
 
 module.exports = {
-    up: async (queryInterface) => {
+    up: async () => {
         console.log(`process.env.NODE_ENV = ${process.env.NODE_ENV}`);
         if (process.env.NODE_ENV === "development"){ // seeder can only run in development
-            // delete any existing entries
-            await queryInterface.bulkDelete("Messages", null, {});
-            await queryInterface.bulkDelete("Conversations", null, {});
-            await queryInterface.bulkDelete("Contacts", null, {});
-            await queryInterface.bulkDelete("SigninOptions", null, {});
-            await queryInterface.bulkDelete("Users", null, {});
+            // delete any existing entries and reset any auto-incrementing keys
+            await Message.sync({ force: true });
+            await Participant.sync({ force: true });
+            await Conversation.sync({ force: true });
+            await Contact.sync({ force: true });
+            await SigninOption.sync({ force: true });
+            await User.sync({ force: true });
 
             console.log("All messages, conversations, contacts and users have been deleted from the database.");
 
@@ -233,52 +234,63 @@ module.exports = {
             let participants = [
                 {
                     userId: mainUser,
-                    conversationId: conv1
+                    conversationId: conv1,
+                    isAdmin: true
                 },
                 {
                     userId: bff1,
-                    conversationId: conv1
+                    conversationId: conv1,
+                    isAdmin: true
                 },
 
                 {
                     userId: mainUser,
-                    conversationId: conv2
+                    conversationId: conv2,
+                    isAdmin: true
                 },
                 {
                     userId: bff2,
-                    conversationId: conv2
+                    conversationId: conv2,
+                    isAdmin: true
                 },
 
                 {
                     userId: mainUser,
-                    conversationId: conv3
+                    conversationId: conv3,
+                    isAdmin: true
                 },
                 {
                     userId: bff3,
-                    conversationId: conv3
+                    conversationId: conv3,
+                    isAdmin: true
                 },
 
                 {
                     userId: mainUser,
-                    conversationId: conv4
+                    conversationId: conv4,
+                    isAdmin: true
                 },
                 {
                     userId: bff4,
-                    conversationId: conv4
+                    conversationId: conv4,
+                    isAdmin: true
                 },
 
                 {
                     userId: mainUser,
-                    conversationId: conv5
+                    conversationId: conv5,
+                    isAdmin: true
                 },
                 {
                     userId: bff5,
-                    conversationId: conv5
+                    conversationId: conv5,
+                    isAdmin: true
                 },
 
                 {
                     userId: mainUser,
-                    conversationId: conv6
+                    conversationId: conv6,
+                    isAdmin: true
                 },
                 {
                     userId: bff1,
@@ -503,13 +515,14 @@ module.exports = {
         }
     },
 
-    down: async (queryInterface) => {
+    down: async () => {
         if (process.env.NODE_ENV === "development"){ // seeder can only run in development
-            await queryInterface.bulkDelete("Messages", null, {});
-            await queryInterface.bulkDelete("Conversations", null, {});
-            await queryInterface.bulkDelete("Contacts", null, {});
-            await queryInterface.bulkDelete("SigninOptions", null, {});
-            await queryInterface.bulkDelete("Users", null, {});
+            await Message.sync({ force: true });
+            await Participant.sync({ force: true });
+            await Conversation.sync({ force: true });
+            await Contact.sync({ force: true });
+            await SigninOption.sync({ force: true });
+            await User.sync({ force: true });
 
             console.log("All messages, conversations, contacts and users have been deleted from the database.");
         } else {


### PR DESCRIPTION
###  I have:
- [X] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] Covered the code with tests that prove my fix is effective or that my feature works (note that PRs
without tests will be REJECTED)
- [ ] New and existing unit tests pass locally with my changes

## How Has This Been Tested?

I deleted my db several times and ran through the quick setup in the README.md file, ran the `npm run dev-quick-server` command a few times without restarting the setup so the db would be reseeded. Then I used the TablePlus app to check the tables to make sure the keys were reset. Then I navigated through the app to make sure it was still functional.

---

### What is the purpose of your *pull request*?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of your *pull request* and other information

In the seeder file:
- The auto-incrementing keys are reset when the tables are cleared
- The Participants table is now cleared in both up and down functions
- isAdmin is now being set in the appropriate participant objects