### PR TITLE
style: keep send button on mobile screens📱

### DIFF
--- a/client/src/styles/chat.css
+++ b/client/src/styles/chat.css
@@ -226,7 +226,7 @@ form.interactions {
 }
 
 form.interactions input.textBox {
-    width: 92%;
+    width: 85%;
     padding: 8px;
     outline: none;
     margin-right: 4px;
@@ -235,6 +235,12 @@ form.interactions input.textBox {
     color: var(--text);
     border-radius: 4px;
     height: fit-content
+}
+
+@media screen and (min-width: 768px) {
+    form.interactions input.textBox {
+        width: 90%;
+    }
 }
 
 @media screen and (min-width: 1024px) {
@@ -253,23 +259,17 @@ form.interactions input:focus {
 }
 
 form.interactions button.enterBtn {
-    display: none;
+    border: none;
+    background-color: transparent;
+    padding: 2px;
+    width: 25px;
+    display: block;
 }
 
-@media screen and (min-width: 1024px) {
-    form.interactions button.enterBtn {
-        border: none;
-        background-color: transparent;
-        padding: 2px;
-        width: 25px;
-        display: block;
-    }
-
-    form.interactions button.enterBtn svg {
-        transform: rotate(90deg);
-        fill: var(--icon);
-        width: 100%;
-    }
+form.interactions button.enterBtn svg {
+    transform: rotate(90deg);
+    fill: var(--icon);
+    width: 100%;
 }
 
 form.interactions button.enterBtn:hover {


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

---

### What is the purpose of your *pull request*?
- [x] Improvement

### Description of your *pull request* and other information

This PR addresses #94 and keeps the send button available on mobile sized screens, making it easier to send messages. 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/43832407/162584402-35acf6a4-73d3-4175-87c0-03d8325ca5ca.png)

closes #94 