### PR TITLE
➖ remove node v12 from the testing matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

---

### What is the purpose of your *pull request*?
- [x] Improvement

### Description of your *pull request* and other information

Node v12 should be removed as a supported node version in our tests as it is approaching its EOL date. Furthermore, i believe this project makes use of functions that are not actually supported in node 12 😅.