### PR TITLE
Updated production deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,24 @@ node_modules/
 # testing
 coverage/
 
+.expo/
+.expo-shared/
+npm-debug.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+*.orig.*
+web-build/
+*swp
+
+config.json
+.env*
+
+# macOS
+.DS_Store
+
 # production
 build/
 server/data
@@ -22,6 +40,7 @@ server/data
 .env.test.local
 .env.production.local
 boop-secret.yaml
+*kubeconfig*.yaml
 
 *.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,18 +30,12 @@ config.json
 build/
 server/data
 
-# misc
-.env
-.scss
-.css
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+# kubernetes
 boop-secret.yaml
 *kubeconfig*.yaml
 
+# misc
+.scss
+.css
 *.log
-
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ along with their mentor David Fowler (Partner Software Architect at Microsoft).
 - [💻 Using the client](#-using-the-client)
 - [🐋 Building a docker image](#-building-a-docker-image)
 - [☸ Deploying to Kubernetes Digital Ocean](#-deploying-to-kubernetes-digital-ocean)
+- [☸ Redeploying to Kubernetes Digital Ocean](#-redeploying-to-kubernetes-digital-ocean)
 
 ## 🔻Downloading the project
 
@@ -66,6 +67,7 @@ The ERD for the database can be found [here](https://dbdiagram.io/d/612bbd55825b
 ### 📄 Setting up Environment Variables
 
 1. Make a .env file at the root of the server directory, with your values for the variables in server/env.sample. 
+2. Make a .env.production file at the root of the server directory, with your values for the variables in server/env.production.sample
 
 ### Getting the server to work
 
@@ -227,12 +229,30 @@ The app should then be accessible on port 8080. From here you will need to run t
 
 ## ☸ Deploying to Kubernetes Digital Ocean
 
-1. Obtain your yaml key for `kubectl` from DigitalOcean in Kubernetes overview section, with the download config file button. This is required if your are using kubectl to manage the kubernetes cluster; this is not required for `doctl`.
+1. Make sure your env variables in server/.env.production have the correct values.
+   
+2. Obtain your yaml key for `kubectl` from DigitalOcean in Kubernetes overview section, with the download config file button. This is required if your are using kubectl to manage the kubernetes cluster; this is not required for `doctl`.
 
     <i>If you are using a *nix system, the deploy-script.bash script can run the following commands automatically. Simply pass the path to the yaml key for kubectl as the first arg (in project root: `./deploy-script.bash <path to yaml key>`).</i>
 
-2. Use `npm run make-yaml-secrets` in the project root to create a secret yaml file (./boop-secret.yaml). The secrets can be pushed to DigitalOcean with kubectl using the command `kubectl --kubeconfig="/path/to/your/yaml/key" apply -f /path/to/your/secret.yaml`.
+3. Use `npm run make-yaml-secrets` in the project root to create a secret yaml file (./boop-secret.yaml). The secrets can be pushed to DigitalOcean with kubectl using the command `kubectl --kubeconfig="/path/to/your/yaml/key" apply -f /path/to/your/secret.yaml`.
 
-3. The HOME_URL var in the boop-deployment.yaml file needs to be filled in with the url to be used for the app. You can then push the deployment to DigitalOcean using `kubectl --kubeconfig="/path/to/your/yaml/key" create -f ../path/to/boop-deployment.yaml`.
+4. The HOME_URL var in the boop-deployment.yaml file needs to be filled in with the url to be used for the app. You can then push the deployment to DigitalOcean using `kubectl --kubeconfig="/path/to/your/yaml/key" create -f ../path/to/boop-deployment.yaml`.
 
-4. To create the service to expose the created pods to the outside world, use the boop-service.yaml. The command to push is `kubectl --kubeconfig="/path/to/your/yaml/key" apply -f /path/to/boop-service.yaml`.
+5. To create the service to expose the created pods to the outside world, use the boop-service.yaml. The command to push is `kubectl --kubeconfig="/path/to/your/yaml/key" apply -f /path/to/boop-service.yaml`.
+
+## ☸ Redeploying to Kubernetes Digital Ocean
+
+If you want to update the env variables used after previously deploying to Kubernetes Digital Ocean:
+
+1. Update the env values in your server/.env.production file
+   
+    <i>If you are using a *nix system, the redeploy-script.bash script can run the following commands automatically. Simply pass the path to the yaml key for kubectl as the first arg (in project root: `./redeploy-script.bash <path to yaml key>`).</i>
+
+2. Delete the current deployment using `kubectl --kubeconfig="/path/to/your/yaml/key" delete deployment boop-deployment`
+
+3. Use `npm run make-yaml-secrets` in the project root to create a secret yaml file (./boop-secret.yaml) with the updated env values. The secrets can be pushed to DigitalOcean with kubectl using the command `kubectl --kubeconfig="/path/to/your/yaml/key" apply -f /path/to/your/secret.yaml`.
+
+4. The HOME_URL var in the boop-deployment.yaml file needs to be filled in with the url to be used for the app. You can then push the deployment to DigitalOcean using `kubectl --kubeconfig="/path/to/your/yaml/key" create -f ../path/to/boop-deployment.yaml`.
+
+5. To create the service to expose the created pods to the outside world, use the boop-service.yaml. The command to push is `kubectl --kubeconfig="/path/to/your/yaml/key" apply -f /path/to/boop-service.yaml`.

--- a/redeploy-script.bash
+++ b/redeploy-script.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+kubectl --kubeconfig="$1" delete deployment boop-deployment
+npm run make-yaml-secrets
+kubectl --kubeconfig="$1" apply -f boop-secret.yaml
+kubectl --kubeconfig="$1" create -f boop-deployment.yaml
+kubectl --kubeconfig="$1" apply -f boop-service.yaml

--- a/server/boop-secrets.js
+++ b/server/boop-secrets.js
@@ -4,7 +4,7 @@ const yaml = require("js-yaml");
 const fs   = require("fs");
 
 const dotenv = require("dotenv");
-dotenv.config();
+dotenv.config({ path: "./.env.production" });
 
 try {
     const secrets = yaml.dump(
@@ -23,7 +23,7 @@ try {
                 DB_USERNAME: process.env.DB_USERNAME,
                 DB_PASSWORD: process.env.DB_PASSWORD,
                 DB_HOST: process.env.DB_HOST,
-                DB_PORT: Number(process.env.DB_PORT),
+                DB_PORT: process.env.DB_PORT,
             }
         }
     );

--- a/server/env.production.sample
+++ b/server/env.production.sample
@@ -1,4 +1,4 @@
-NODE_ENV=development
+NODE_ENV=production
 
 GOOGLE_CLIENT_ID=< Google client Id goes here >
 GOOGLE_CLIENT_SECRET=< Google client secret goes here >
@@ -14,8 +14,4 @@ DB_PASSWORD=<database-password goes here >
 DB_HOST=<database-host goes here > e.g = 127.0.0.1
 DB_PORT=<database-port here> e.g. 5432
 
-HOME_URL=<home url goes here > e.g. = http://localhost:3000
-
-USER_INFO_EMAIL=<your-email-before-@gmail.com> ONLY NEEDED FOR TESTING
-USER_INFO_FIRST_NAME=<you-first-name>  ONLY NEEDED FOR TESTING
-USER_INFO_LAST_NAME=<you-last-name>  ONLY NEEDED FOR TESTING
+HOME_URL=<home url goes here >


### PR DESCRIPTION
### I have:
- [X] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

## How Has This Been Tested?

I made a .env.production file, ran the redeploy-script.bash script and saw the new env variables show up in the environment variables section for a new deployment on our cluster's Kubernetes dashboard in Digital Ocean 

---

### What is the purpose of your *pull request*?
- [X] Improvement
- [X] New feature (non-breaking change which adds functionality)

### Description of your *pull request* and other information

- Added the ability to use a server/.env.production file to store production env values
- Used this file in server/boop-secrets.js
- Added redeploy-script.bash to delete an old deployment and create a new one with the updated production env values in .env.production
- Updated README file so user knows production variables go in server/.env.production and they have instructions to redeploy so the values can be updated