### PR TITLE
🗜 Reduce docker image size by splitting the Dockerfile into stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,28 @@
+FROM node:14.18.1-alpine as buildStage
+
+RUN mkdir -p /home/react
+WORKDIR /home/react
+
+COPY client/package.json client/package-lock.json ./
+RUN npm ci --production
+
+COPY client/ ./
+RUN npm run build
+
+
 FROM node:14.18.1-alpine
 
 RUN mkdir -p /home/boop
 WORKDIR /home/boop
 
-COPY client/package.json package-lock.json client/
-COPY server/package.json package-lock.json server/
-
+COPY server/package.json server/package-lock.json server/
 RUN cd server && npm ci --production
-RUN cd client && npm ci --production
 
 ENV NODE_ENV=production
 ENV PORT=5000
 
 COPY server/ server/
-COPY client/ client/
-RUN cd client && npm run build
+COPY --from=buildStage /home/react/build client/build
 
 EXPOSE 5000
 CMD ["node", "server/bin/www"]


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

---

### What is the purpose of your *pull request*?
- [x] Improvement

### Description of your *pull request* and other information

This PR splits the building of the react frontend from the setup of the express backend in the Dockerfile. This is done so that the packages required to build the react frontend are not left in the final output image (as they are not needed beyond building the static files).