### PR TITLE
Untitled chats and leaving solo convos

### DIFF
--- a/client/src/components/messenger/Chat.js
+++ b/client/src/components/messenger/Chat.js
@@ -95,7 +95,7 @@ const Chat = ({ conversationId, title, participants, closeChat, isDark }) => {
         let result = null;
         switch (action) {
             case optionsEnum.leave:
-                if (participants.length === 2) // if 1 on 1 conversation, simply leave
+                if (participants.length <= 2) // if 1 on 1 or solo conversation, simply leave
                     result = await ConversationsController.leaveConversation(token, conversationId);
                 else {
                     // check if user is admin
@@ -295,7 +295,7 @@ const Chat = ({ conversationId, title, participants, closeChat, isDark }) => {
             <header className="chat_title">
                 <div className="img_and_back">
                     <Arrow onClick={cleanUp}/>
-                    <img src={"https://picsum.photos/400?id=" + title} className="skeleton" alt="chat" />
+                    <img src={"https://picsum.photos/400?id=" + conversationId} className="skeleton" alt="chat" />
                 </div>
                 <span>{title || "Untitled Chat"}</span>
                 <Options action={showChatOptions} />
@@ -303,7 +303,7 @@ const Chat = ({ conversationId, title, participants, closeChat, isDark }) => {
             { optionsDialog ?
                 <ChatOptionsDialog
                     onClose={onOptionsDialogClose}
-                    img={"https://picsum.photos/400?id=" + title}
+                    img={"https://picsum.photos/400?id=" + conversationId}
                     title={title}
                     participants={participants}
                     addUsers={() => setAddUsersDialog(true)}

--- a/client/src/components/messenger/Conversations.js
+++ b/client/src/components/messenger/Conversations.js
@@ -25,14 +25,14 @@ const Conversations = () => {
     const [contacts, setContacts] = useState([]);
 
     // Get the token and userInfo from the users global state.
-    const { token, userInfo: { displayName, imageUrl } } = useSelector((state) => state.user);
+    const { token, userInfo: { displayName, imageUrl, id: userId } } = useSelector((state) => state.user);
 
     // get the currently selected conversation
     const { id: currentlySelectedConvo } = useSelector(state => state.conversations.currentConversation);
 
     useEffect(() => {
         const runAsync = async () => {
-            const result = await ConversationsController.getConversations(token, socket);
+            const result = await ConversationsController.getConversations(token, socket, userId);
             if (!result.success) {
                 displayDialog({
                     title: "Error",
@@ -99,13 +99,6 @@ const Conversations = () => {
                     });
                     return;
                 }
-                if (title.length < 1) {
-                    // create a title from the chosen participants' names
-                    title = list
-                        .map((i) => i.displayName)
-                        .reduce((prevValue, curValue) => prevValue + curValue + ", ", "You, ")
-                        .substring(0, 25);
-                }
                 const { success, id } = await ConversationsController.createConversation(
                     token, list.map(i => i.id), title);
                 if (!success) {
@@ -165,7 +158,7 @@ const Conversations = () => {
                         .sort(sortConversations).map((chat, i) => (
                             <ConversationItem
                                 name={chat.title}
-                                img={chat.imgUrl ?? "https://picsum.photos/400?id=" + chat.title}
+                                img={chat.imgUrl ?? "https://picsum.photos/400?id=" + chat.id}
                                 lastMsg={ConversationsController.getLastMessage(chat)}
                                 lastDate={ConversationsController.getLastMessageDate(chat)}
                                 unread={chat.unread}

--- a/client/src/components/messenger/controllers/Conversations.js
+++ b/client/src/components/messenger/controllers/Conversations.js
@@ -54,7 +54,8 @@ export const ConversationsController = {
                             if (p.id !==  userId){ result.push(p.displayName); }
                             return result;
                         }, []).join(", ");
-                        convo.title = `You${participantNames.length > 0 ? "," : ""} ${participantNames.substring(0, participantNamesMaxLength)}${
+                        convo.title = `You${participantNames.length > 0 ? "," : ""} ${participantNames
+                            .substring(0, participantNamesMaxLength)}${
                             participantNames.length > participantNamesMaxLength ? "..." : ""
                         }`;
                     }

--- a/client/src/components/messenger/controllers/Conversations.js
+++ b/client/src/components/messenger/controllers/Conversations.js
@@ -1,4 +1,5 @@
-import { participantNamesMaxLength } from "./controllerUtils";
+// the max length of participants' names used to auto generate a title
+export const participantNamesMaxLength = 25;
 
 const evaluateDate = (lastDate) => {
     // decide whether to return the date as (d/mm/yy) or as time(\d{2}:\d{2} (A|P)M)

--- a/client/src/components/messenger/controllers/Conversations.js
+++ b/client/src/components/messenger/controllers/Conversations.js
@@ -1,3 +1,5 @@
+import { participantNamesMaxLength } from "./controllerUtils";
+
 const evaluateDate = (lastDate) => {
     // decide whether to return the date as (d/mm/yy) or as time(\d{2}:\d{2} (A|P)M)
     // if lastDate within the last 23 hrs display time else use date format
@@ -19,7 +21,7 @@ const evaluateDate = (lastDate) => {
 };
 
 export const ConversationsController = {
-    getConversations: async (token, socket) => {
+    getConversations: async (token, socket, userId) => {
         // make request for the conversations of user and wait for the json response
         try {
             const res = await fetch("/api/conversations", {
@@ -44,13 +46,29 @@ export const ConversationsController = {
                 "joinConversations",
                 result.conversationList.map((item) => item.id)
             );
-            return result?.conversationList ? {
-                success: true,
-                conversations: result.conversationList
-            } : {
-                success: false,
-                conversations: []
-            };
+            if (result && result.conversationList){
+                for (const convo of result.conversationList) {
+                    // if title is blank make 1 using the participant's display names
+                    if (!convo.title || convo.title.length < 1) {
+                        let participantNames = convo.participants.reduce((result, p) => {
+                            if (p.id !==  userId){ result.push(p.displayName); }
+                            return result;
+                        }, []).join(", ");
+                        convo.title = `You${participantNames.length > 0 ? "," : ""} ${participantNames.substring(0, participantNamesMaxLength)}${
+                            participantNames.length > participantNamesMaxLength ? "..." : ""
+                        }`;
+                    }
+                }
+                return {
+                    success: true,
+                    conversations: result.conversationList
+                };
+            } else {
+                return {
+                    success: false,
+                    conversations: []
+                };
+            }
         } catch (e) {
             return {
                 success: false,

--- a/client/src/components/messenger/controllers/Socket.js
+++ b/client/src/components/messenger/controllers/Socket.js
@@ -1,6 +1,6 @@
 import store from "./../../../redux-store/store";
 import { addConversation, updateConversation, updateCurrentConversation } from "../../../redux-store/conversationSlice";
-import { participantNamesMaxLength } from "./controllerUtils";
+import { participantNamesMaxLength } from "./Conversations";
 
 export const SocketController = {
     initListeners: (socket) => {

--- a/client/src/components/messenger/controllers/Socket.js
+++ b/client/src/components/messenger/controllers/Socket.js
@@ -1,10 +1,24 @@
 import store from "./../../../redux-store/store";
 import { addConversation, updateConversation, updateCurrentConversation } from "../../../redux-store/conversationSlice";
+import { participantNamesMaxLength } from "./controllerUtils";
 
 export const SocketController = {
     initListeners: (socket) => {
         // Adds new conversation to conversation state.
         socket.off("newConversation").on("newConversation", (convoObject) => {
+
+            // if title is blank make 1 using the participant's display names
+            if (!convoObject.conversation.title || convoObject.conversation.title.length < 1){
+                let participantNames = convoObject.conversation.participants.reduce((result, p) => {
+                    if (p.id !==  store.getState().user.userInfo.id){ result.push(p.displayName); }
+                    return result;
+                }, []).join(", ");
+                convoObject.conversation.title = `You${participantNames.length > 0 ? "," : ""} ${participantNames
+                    .substring(0, participantNamesMaxLength)}${
+                    participantNames.length > participantNamesMaxLength ? "..." : ""
+                }`;
+            }
+
             store.dispatch(addConversation(convoObject.conversation));
             // send back the conversation to the server to join client to that socket rooms
             socket.emit("joinConversations", [convoObject.conversation.id]);

--- a/client/src/components/messenger/controllers/controllerUtils.js
+++ b/client/src/components/messenger/controllers/controllerUtils.js
@@ -1,2 +1,0 @@
-// the max length of participants' names used to auto generate a title
-export const participantNamesMaxLength = 25;

--- a/client/src/components/messenger/controllers/controllerUtils.js
+++ b/client/src/components/messenger/controllers/controllerUtils.js
@@ -1,0 +1,2 @@
+// the max length of participants' names used to auto generate a title
+export const participantNamesMaxLength = 25;

--- a/server/controllers/Conversations.js
+++ b/server/controllers/Conversations.js
@@ -206,7 +206,32 @@ module.exports.leaveConversation = async (req, res) => {
         let deletedConversationRow = await Conversation.destroy({
             where: {
                 id: conversationId,
+            }
+        }).catch((err) => {
+            //catch any errors
+            let msg = err.message || "Some error occurred while deleting the conversation.";
+            logger.error(msg + `${userId} - ${conversationId}`);
+            res.status(500).send({ msg });
+        });
+
+        // delete associated participant (has to be done manually because participant's soft delete breaks cascade)
+        await Participant.destroy({
+            where: {
+                conversationId: conversationId,
             },
+            force: true
+        }).catch((err) => {
+            //catch any errors
+            let msg = err.message || "Some error occurred while deleting the conversation.";
+            logger.error(msg + `${userId} - ${conversationId}`);
+            res.status(500).send({ msg });
+        });
+
+        // delete associated messages (has to be done manually because participant's soft delete breaks cascade)
+        await Message.destroy({
+            where: {
+                conversationId: conversationId,
+            }
         }).catch((err) => {
             //catch any errors
             let msg = err.message || "Some error occurred while deleting the conversation.";


### PR DESCRIPTION
### I have:
- [X] [Searched](https://github.com/BoopChat/boop/pulls) the bugtracker for similar pull requests
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

## How Has This Been Tested?

Created a chat with 2 participants and without a title and one was auto generated for me (unique for each user), but was blank in the db.

Had both participants leave the chat and it along with all its participants and messages were deleted. 

---

### What is the purpose of your *pull request*?
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement
- [X] New feature (non-breaking change which adds functionality)

### Description of your *pull request* and other information
Improvements:
- conversation titles can be left blank during creation. Will be dynamically created for each user ("You, <dNames of other participants (length <= 25)>")
- added a util to set the max length of participants' names used in dynamic title
- picsum images for conversations use the convo's id as id instead of the title so all users see the same image

Fix:
- allow users to leave solo convos
- manually deleting associated messages and participants when delete a conversation (auto cascade was broken when soft delete was added to participants)

closes #104 